### PR TITLE
false or nil lookup should also be returned

### DIFF
--- a/lib/hiera/backend/regex_backend.rb
+++ b/lib/hiera/backend/regex_backend.rb
@@ -32,7 +32,7 @@ class Hiera
            data.each do |item|
              lineno = lineno + 1
              item.each_key do |regex_key|
-               if scope[scope_key] =~ /#{regex_key}/ and item[regex_key][key]
+               if scope[scope_key] =~ /#{regex_key}/ and item[regex_key].has_key?(key)
                  Hiera.debug("#{scope_key} with value of '#{scope[scope_key]}' matched regex /#{regex_key}/ at #{source}:#{lineno}")
                  new_answer = Backend.parse_answer(item[regex_key][key], scope)
                  case resolution_type

--- a/tests/hiera-data/fqdn/fqdn.regex
+++ b/tests/hiera-data/fqdn/fqdn.regex
@@ -8,6 +8,7 @@
      postfix::trusted_networks:
       network1: '10.0.0.0/8'
       network2: '172.16.0.0/16'
+     postfix::spamassassin: false
  - '^mailin.*':
      postfix::smtp_relay: 'localhost'
      postfix::array: ['all-mailin']


### PR DESCRIPTION
Ran into an issue while using this gem in production. If I set the value of a key to `false` in my fqdn.regex file, the lookup will fail and hiera will move to the next level in hierarchy. On debugging the issue, I found out the condition for checking the key in every regex item in fqdn.regex had a minor issue.

Please take a look and if this looks right, make a release. We love this gem :) and would love to get rid of this issue. Until then, I have to stringify my negative boolean to make things work in production.
